### PR TITLE
Dynamic realtime item updates

### DIFF
--- a/client/src/components/main-content/SectionList.jsx
+++ b/client/src/components/main-content/SectionList.jsx
@@ -20,13 +20,10 @@ import GhostComponent from "./Add/GhostComponent";
 import SectionModal from "./Sections/SectionModal";
 import DroppableSection from "./Sections/DroppableSection";
 import NewSectionDropZone from "./Sections/NewSectionDropZone";
-import useItemSectionHandlers from "../../hooks/useItemSocketHandlers";
+import useItemSocketHandlers from "../../hooks/useItemSocketHandlers";
 import useSectionSocketHandlers from "../../hooks/useSectionSocketHandlers";
 import customCollisionDetection from "../../utils/customCollisionDetection";
-import {
-  SectionActions,
-  ViewModes,
-} from "../../utils/constants";
+import { SectionActions, ViewModes } from "../../utils/constants";
 import {
   findItemBySection,
   handleDragEnd as handleDragEndUtil,
@@ -51,7 +48,7 @@ const SectionList = () => {
   const [editingItem, setEditingItem] = useState(null);
 
   useSectionSocketHandlers({ setSections, setSectionOrder, username });
-  useItemSectionHandlers({ setSections, setSectionOrder, username });
+  useItemSocketHandlers({ setSections, setSectionOrder, username });
 
   useEffect(() => {
     if (!isAuthenticated || !username) return;
@@ -66,15 +63,16 @@ const SectionList = () => {
       const order = [];
       data.forEach((section) => {
         const { _id, items = [], ...rest } = section;
-        sectionsObj[_id] = {
+        const id = _id;
+        sectionsObj[id] = {
           ...rest,
-          id: _id,
+          id,
           items: items.map(({ _id: itemId, ...itemRest }) => ({
             ...itemRest,
             id: itemId,
           })),
         };
-        order.push(_id);
+        order.push(id);
       });
       setSections(sectionsObj);
       setSectionOrder(order);
@@ -109,7 +107,7 @@ const SectionList = () => {
       getAccessTokenSilently,
     });
 
-    const sectionId = newSection._id;
+    const sectionId = newSection.id;
 
     setSections((prev) => ({
       ...prev,
@@ -130,7 +128,7 @@ const SectionList = () => {
 
     if (editingItem) {
       await apiFetch({
-        endpoint: `${URL}/api/items/${targetSectionId}/items/${editingItem.id}`,
+        endpoint: `${URL}/api/items/${targetSectionId}/items/${editingItem.id}/${username}`,
         method: "PUT",
         body: { content, link, notes, sectionId: targetSectionId },
         getAccessTokenSilently,

--- a/client/src/hooks/useItemSocketHandlers.jsx
+++ b/client/src/hooks/useItemSocketHandlers.jsx
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+import { itemEvents } from "../utils/constants";
+import { socket } from "../utils/socket";
+
+const useItemSectionHandlers = ({ setSections, username }) => {
+  useEffect(() => {
+    const handleItemCreated = (item) => {
+      setSections((prev) => {
+        const sectionId = item.sectionId;
+        if (!prev[sectionId]) return prev;
+        if (
+          prev[sectionId].items.some(
+            (existingItem) => existingItem.id === item.id || existingItem.id === item.id
+          )
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [sectionId]: {
+            ...prev[sectionId],
+            items: [...prev[sectionId].items, { ...item, id: item.id }],
+          },
+        };
+      });
+    };
+
+    const handleItemUpdated = (item) => {
+      setSections((prev) => {
+        const newSections = { ...prev };
+        for (const sectionId in newSections) {
+          newSections[sectionId] = {
+            ...newSections[sectionId],
+            items: newSections[sectionId].items.filter(
+              (existingItem) => existingItem.id !== item.id
+            ),
+          };
+        }
+        const destSectionId = item.sectionId;
+        if (newSections[destSectionId]) {
+          newSections[destSectionId] = {
+            ...newSections[destSectionId],
+            items: [
+              ...newSections[destSectionId].items,
+              { ...item, id: item.id },
+            ],
+          };
+        }
+        return newSections;
+      });
+    };
+
+    const handleItemDeleted = ({ itemId }) => {
+      setSections((prev) => {
+        const newSections = { ...prev };
+        for (const sectionId in newSections) {
+          newSections[sectionId] = {
+            ...newSections[sectionId],
+            items: newSections[sectionId].items.filter(
+              (existingItem) => existingItem.id !== itemId
+            ),
+          };
+        }
+        return newSections;
+      });
+    };
+
+    const handleItemOrderUpdated = ({ sectionId, order }) => {
+      setSections((prev) => {
+        if (!prev[sectionId]) return prev;
+        const itemsById = {};
+        prev[sectionId].items.forEach((item) => {
+          itemsById[item.id] = item;
+        });
+        return {
+          ...prev,
+          [sectionId]: {
+            ...prev[sectionId],
+            items: order.map((id) => itemsById[id]).filter(Boolean),
+          },
+        };
+      });
+    };
+
+    socket.on(itemEvents.ITEM_CREATED, handleItemCreated);
+    socket.on(itemEvents.ITEM_UPDATED, handleItemUpdated);
+    socket.on(itemEvents.ITEM_DELETED, handleItemDeleted);
+    socket.on(itemEvents.ITEM_ORDER_UPDATED, handleItemOrderUpdated);
+
+    return () => {
+      socket.off(itemEvents.ITEM_CREATED, handleItemCreated);
+      socket.off(itemEvents.ITEM_UPDATED, handleItemUpdated);
+      socket.off(itemEvents.ITEM_DELETED, handleItemDeleted);
+      socket.off(itemEvents.ITEM_ORDER_UPDATED, handleItemOrderUpdated);
+    };
+  }, [setSections, username]);
+};
+
+export default useItemSectionHandlers;

--- a/client/src/hooks/useItemSocketHandlers.jsx
+++ b/client/src/hooks/useItemSocketHandlers.jsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { itemEvents } from "../utils/constants";
 import { socket } from "../utils/socket";
 
-const useItemSectionHandlers = ({ setSections, username }) => {
+const useItemSocketHandlers = ({ setSections, username }) => {
   useEffect(() => {
     const handleItemCreated = (item) => {
       setSections((prev) => {
@@ -10,7 +10,7 @@ const useItemSectionHandlers = ({ setSections, username }) => {
         if (!prev[sectionId]) return prev;
         if (
           prev[sectionId].items.some(
-            (existingItem) => existingItem.id === item.id || existingItem.id === item.id
+            (existingItem) => existingItem.id === item.id
           )
         ) {
           return prev;
@@ -19,37 +19,56 @@ const useItemSectionHandlers = ({ setSections, username }) => {
           ...prev,
           [sectionId]: {
             ...prev[sectionId],
-            items: [...prev[sectionId].items, { ...item, id: item.id }],
+            items: [...prev[sectionId].items, { item, id: item.id }],
           },
         };
       });
     };
 
     const handleItemUpdated = (item) => {
+      const normalizedItem = {
+        ...item,
+        id: (item.id || item._id)?.toString(),
+        sectionId: item.sectionId?.toString(),
+      };
+      const destSectionId = normalizedItem.sectionId;
+
       setSections((prev) => {
-        const newSections = { ...prev };
-        for (const sectionId in newSections) {
-          newSections[sectionId] = {
-            ...newSections[sectionId],
-            items: newSections[sectionId].items.filter(
-              (existingItem) => existingItem.id !== item.id
-            ),
+        // if item is moving between sections
+        const sourceSectionId = Object.entries(prev).find(
+          ([sectionId, section]) =>
+            sectionId !== destSectionId &&
+            section.items.some((i) => i.id === normalizedItem.id)
+        )?.[0];
+
+        if (sourceSectionId) {
+          return {
+            ...prev,
+            [sourceSectionId]: {
+              ...prev[sourceSectionId],
+              items: prev[sourceSectionId].items.filter(
+                (i) => i.id !== normalizedItem.id
+              ),
+            },
+            [destSectionId]: {
+              ...prev[destSectionId],
+              items: [...prev[destSectionId].items, normalizedItem],
+            },
+          };
+        } else {
+          // update item in the same section
+          return {
+            ...prev,
+            [destSectionId]: {
+              ...prev[destSectionId],
+              items: prev[destSectionId].items.map((i) =>
+                i.id === normalizedItem.id ? { ...i, ...normalizedItem } : i
+              ),
+            },
           };
         }
-        const destSectionId = item.sectionId;
-        if (newSections[destSectionId]) {
-          newSections[destSectionId] = {
-            ...newSections[destSectionId],
-            items: [
-              ...newSections[destSectionId].items,
-              { ...item, id: item.id },
-            ],
-          };
-        }
-        return newSections;
       });
     };
-
     const handleItemDeleted = ({ itemId }) => {
       setSections((prev) => {
         const newSections = { ...prev };
@@ -96,4 +115,4 @@ const useItemSectionHandlers = ({ setSections, username }) => {
   }, [setSections, username]);
 };
 
-export default useItemSectionHandlers;
+export default useItemSocketHandlers;

--- a/client/src/hooks/useSectionSocketHandlers.jsx
+++ b/client/src/hooks/useSectionSocketHandlers.jsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { sectionEvents } from "../utils/constants";
+import { socket } from "../utils/socket";
+
+const useSectionSocketHandlers = ({
+  setSections,
+  setSectionOrder,
+  username,
+}) => {
+  useEffect(() => {
+    const handleSectionCreated = (section) => {
+      setSections((prev) => ({
+        ...prev,
+        [section.id]: { ...section, id: section.id, items: [] },
+      }));
+      setSectionOrder((prev) => [...prev, section.id]);
+    };
+
+    const handleSectionUpdated = (section) => {
+      setSections((prev) => ({
+        ...prev,
+        [section.id]: { ...prev[section.id], ...section },
+      }));
+    };
+
+    const handleSectionDeleted = ({ sectionId }) => {
+      setSections((prev) => {
+        const copy = { ...prev };
+        delete copy[sectionId];
+        return copy;
+      });
+      setSectionOrder((prev) => prev.filter((id) => id !== sectionId));
+    };
+
+    const handleSectionOrderUpdated = (order) => {
+      setSectionOrder(order);
+    };
+
+    socket.on(sectionEvents.SECTION_CREATED, handleSectionCreated);
+    socket.on(sectionEvents.SECTION_UPDATED, handleSectionUpdated);
+    socket.on(sectionEvents.SECTION_DELETED, handleSectionDeleted);
+    socket.on(sectionEvents.SECTION_ORDER_UPDATED, handleSectionOrderUpdated);
+
+    return () => {
+      socket.off(sectionEvents.SECTION_CREATED, handleSectionCreated);
+      socket.off(sectionEvents.SECTION_UPDATED, handleSectionUpdated);
+      socket.off(sectionEvents.SECTION_DELETED, handleSectionDeleted);
+      socket.off(
+        sectionEvents.SECTION_ORDER_UPDATED,
+        handleSectionOrderUpdated
+      );
+    };
+  }, [setSections, setSectionOrder, username]);
+};
+
+export default useSectionSocketHandlers;

--- a/client/src/utils/apiFetch.js
+++ b/client/src/utils/apiFetch.js
@@ -28,5 +28,10 @@ export const apiFetch = async ({
   const res = await fetch(endpoint, fetchOptions);
   if (!res.ok) throw new Error(await res.text());
   const text = await res.text();
-  return text ? JSON.parse(text) : {};
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    return {};
+  }
 };

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -36,3 +36,10 @@ export const sectionEvents = Object.freeze({
   SECTION_DELETED: "section:deleted",
   SECTION_ORDER_UPDATED: "section:orderUpdated",
 })
+
+export const itemEvents = Object.freeze({
+  ITEM_CREATED: "item:created",
+  ITEM_UPDATED: "item:updated",
+  ITEM_DELETED: "item:deleted",
+  ITEM_ORDER_UPDATED: "item:orderUpdated",
+});

--- a/client/src/utils/sectionListUtils.js
+++ b/client/src/utils/sectionListUtils.js
@@ -122,9 +122,9 @@ const handleDragEndItem = (
 
   (async () => {
     await apiFetch({
-      endpoint: `${URL}/api/items/${fromSectionId}/items/${active.id}`,
+      endpoint: `${URL}/api/items/${fromSectionId}/items/${active.id}/${username}/move`,
       method: "PUT",
-      body: { sectionId: toSectionId },
+      body: { toSectionId },
       getAccessTokenSilently,
     });
   })();
@@ -154,7 +154,7 @@ const handleDragEndDelete = (
     }));
     (async () => {
       await apiFetch({
-        endpoint: `${URL}/api/items/${fromSectionId}/items/${active.id}`,
+        endpoint: `${URL}/api/items/${fromSectionId}/items/${active.id}/${username}`,
         method: "DELETE",
         getAccessTokenSilently,
       });

--- a/client/src/utils/sectionListUtils.js
+++ b/client/src/utils/sectionListUtils.js
@@ -46,7 +46,7 @@ const handleDragEndSection = (
 const handleDragEndItem = (
   active,
   over,
-  { setSections, setActiveId, sections, activeId, getAccessTokenSilently }
+  { setSections, setActiveId, sections, activeId, getAccessTokenSilently, username }
 ) => {
   const fromSectionId = active.data.current.sectionId;
   const toSectionId = over.data.current?.sectionId || over.id;
@@ -73,7 +73,7 @@ const handleDragEndItem = (
 
     (async () => {
       await apiFetch({
-        endpoint: `${URL}/api/items/${fromSectionId}/items/order`,
+        endpoint: `${URL}/api/items/${fromSectionId}/items/${username}/order`,
         method: "PUT",
         body: { order: newOrder },
         getAccessTokenSilently,

--- a/client/src/utils/socket.js
+++ b/client/src/utils/socket.js
@@ -3,7 +3,6 @@ const URL = import.meta.env.VITE_API_URL;
 export const socket = io(URL, { transports: ["websocket"] });
 
 socket.on("connect", () => {
-  console.log("Socket connected:", socket.id);
 
 });
 

--- a/server/controllers/itemController.js
+++ b/server/controllers/itemController.js
@@ -5,11 +5,12 @@
 const Section = require("../models/Section");
 const Item = require("../models/Item");
 const itemEvents = require("../events/itemEvents");
+const { ITEMS_FIELD } = require("../utils/constants");
 
 exports.getItems = async (req, res) => {
   try {
     const section = await Section.findById(req.params.sectionId).populate(
-      "items"
+      ITEMS_FIELD
     );
     if (!section) return res.status(404).json({ error: "Section not found" });
     res.json(section.items);

--- a/server/controllers/sectionController.js
+++ b/server/controllers/sectionController.js
@@ -5,6 +5,7 @@
 const Section = require("../models/Section");
 const User = require("../models/User");
 const sectionEvents = require("../events/sectionEvents");
+const { ITEMS_FIELD } = require("../utils/constants");
 
 exports.getSectionsByUsername = async (req, res) => {
   try {
@@ -12,7 +13,7 @@ exports.getSectionsByUsername = async (req, res) => {
     if (!user) return res.status(404).json({ error: "User not found" });
 
     const sections = await Section.find({ userId: user.auth0Id }).populate(
-      "items"
+      ITEMS_FIELD
     );
 
     let orderedSections = sections;

--- a/server/events/itemEvents.js
+++ b/server/events/itemEvents.js
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   emitItemUpdated: (roomId, item) => {
-    if (io) io.to(roomId).emit(itemEvents.ITEM_UPDATED, item);
+   if (io) io.to(roomId).emit(itemEvents.ITEM_UPDATED, item);
   },
 
   emitItemDeleted: (roomId, itemId) => {

--- a/server/events/itemEvents.js
+++ b/server/events/itemEvents.js
@@ -1,0 +1,26 @@
+/*
+ * Handles item related socket events
+ */
+
+let io = null;
+const { itemEvents } = require("../utils/constants");
+
+module.exports = {
+  init: (_io) => { io = _io; },
+
+  emitItemCreated: (roomId, item) => {
+    if (io) io.to(roomId).emit(itemEvents.ITEM_CREATED, item);
+  },
+
+  emitItemUpdated: (roomId, item) => {
+    if (io) io.to(roomId).emit(itemEvents.ITEM_UPDATED, item);
+  },
+
+  emitItemDeleted: (roomId, itemId) => {
+    if (io) io.to(roomId).emit(itemEvents.ITEM_DELETED, { itemId });
+  },
+
+  emitItemOrderUpdated: (roomId, sectionId, order) => {
+    if (io) io.to(roomId).emit(itemEvents.ITEM_ORDER_UPDATED, { sectionId, order });
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -33,9 +33,11 @@ const io = new Server(server, {
 });
 
 require("./events/sectionEvents").init(io);
+require("./events/itemEvents").init(io);
 app.set("io", io);
 
 require("./socket/socket")(io);
+
 
 
 server.listen(PORT, () => {

--- a/server/routes/itemRoutes.js
+++ b/server/routes/itemRoutes.js
@@ -8,8 +8,8 @@ const itemController = require("../controllers/itemController");
 
 router.get("/:sectionId/items", itemController.getItems); // GET api/items/:sectionId/items
 router.post("/:sectionId/items", itemController.createItem); // POST api/items/:sectionId/items
-router.put("/:sectionId/items/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/order
+router.put("/:sectionId/items/:username/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/order
 router.put("/:sectionId/items/:itemId", itemController.updateItem); // PUT api/items/:sectionId/items/:itemId
-router.delete("/:sectionId/items/:itemId", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId
+router.delete("/:sectionId/items/:itemId/:username", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId
 
 module.exports = router;

--- a/server/routes/itemRoutes.js
+++ b/server/routes/itemRoutes.js
@@ -7,10 +7,10 @@ const router = express.Router();
 const itemController = require("../controllers/itemController");
 
 router.get("/:sectionId/items", itemController.getItems); // GET api/items/:sectionId/items
-router.post("/:sectionId/items/:username", itemController.createItem); // POST api/items/:sectionId/items
+router.post("/:sectionId/items/:username", itemController.createItem); // POST api/items/:sectionId/items/:username
 router.put("/:sectionId/items/:username/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/:username/order
-router.put("/:sectionId/items/:itemId/:username/move", itemController.moveItem); // PUT api/items/:sectionId/items/:itemId/move
+router.put("/:sectionId/items/:itemId/:username/move", itemController.moveItem); // PUT api/items/:sectionId/items/:itemId/:username/move
 router.put("/:sectionId/items/:itemId", itemController.updateItem); // PUT api/items/:sectionId/items/:itemId
-router.delete("/:sectionId/items/:itemId/:username", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId
+router.delete("/:sectionId/items/:itemId/:username", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId/:username
 
 module.exports = router;

--- a/server/routes/itemRoutes.js
+++ b/server/routes/itemRoutes.js
@@ -10,7 +10,7 @@ router.get("/:sectionId/items", itemController.getItems); // GET api/items/:sect
 router.post("/:sectionId/items/:username", itemController.createItem); // POST api/items/:sectionId/items/:username
 router.put("/:sectionId/items/:username/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/:username/order
 router.put("/:sectionId/items/:itemId/:username/move", itemController.moveItem); // PUT api/items/:sectionId/items/:itemId/:username/move
-router.put("/:sectionId/items/:itemId", itemController.updateItem); // PUT api/items/:sectionId/items/:itemId
+router.put("/:sectionId/items/:itemId/:username", itemController.updateItem); // PUT api/items/:sectionId/items/:itemId
 router.delete("/:sectionId/items/:itemId/:username", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId/:username
 
 module.exports = router;

--- a/server/routes/itemRoutes.js
+++ b/server/routes/itemRoutes.js
@@ -7,8 +7,9 @@ const router = express.Router();
 const itemController = require("../controllers/itemController");
 
 router.get("/:sectionId/items", itemController.getItems); // GET api/items/:sectionId/items
-router.post("/:sectionId/items", itemController.createItem); // POST api/items/:sectionId/items
-router.put("/:sectionId/items/:username/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/order
+router.post("/:sectionId/items/:username", itemController.createItem); // POST api/items/:sectionId/items
+router.put("/:sectionId/items/:username/order", itemController.updateItemOrder); // PUT api/items/:sectionId/items/:username/order
+router.put("/:sectionId/items/:itemId/:username/move", itemController.moveItem); // PUT api/items/:sectionId/items/:itemId/move
 router.put("/:sectionId/items/:itemId", itemController.updateItem); // PUT api/items/:sectionId/items/:itemId
 router.delete("/:sectionId/items/:itemId/:username", itemController.deleteItem); // DELETE api/items/:sectionId/items/:itemId
 

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -8,8 +8,6 @@ const router = express.Router();
 const userController = require('../controllers/userController');
 
 router.get('/', userController.getCurrentUser); // GET /api/users
-// router.get('/:username/sections', userController.getSectionsByUsername); // GET /api/users/:username/sections
-// router.put('/:username/sections/order', userController.updateSectionOrder); // PUT /api/users/:username/sections/order
 router.post('/', userController.createUser); // POST /api/users
 router.put('/:id', userController.updateUser); // PUT /api/users/:id
 router.delete('/:id', userController.deleteUser); // DELETE /api/users/:id

--- a/server/socket/rooms.js
+++ b/server/socket/rooms.js
@@ -14,9 +14,7 @@ module.exports = (io, socket, usersInRoom) => {
   };
 
   socket.on(roomActions.JOIN, ({ roomId, userId, nickname }) => {
-    console.log(`User ${userId} joined room ${roomId}`);
     socket.join(roomId);
-    console.log("Sockets in room", roomId, ":", Array.from(io.sockets.adapter.rooms.get(roomId) || []));
     if (!usersInRoom[roomId]) usersInRoom[roomId] = {};
     usersInRoom[roomId][socket.id] = {
       id: userId,
@@ -42,7 +40,7 @@ module.exports = (io, socket, usersInRoom) => {
     }
   });
 
-  socket.on("disconnecting", () => {
+  socket.on(roomActions.DISCONNECTING, () => {
     for (const roomId of socket.rooms) {
       if (usersInRoom[roomId]) {
         delete usersInRoom[roomId][socket.id];

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -21,4 +21,11 @@ const sectionEvents = Object.freeze({
   SECTION_ORDER_UPDATED: "section:orderUpdated",
 })
 
-module.exports = { roomActions, COLORS, sectionEvents };
+const itemEvents = Object.freeze({
+  ITEM_CREATED: "item:created",
+  ITEM_UPDATED: "item:updated",
+  ITEM_DELETED: "item:deleted",
+  ITEM_ORDER_UPDATED: "item:orderUpdated",
+});
+
+module.exports = { roomActions, COLORS, sectionEvents, itemEvents };

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -29,4 +29,6 @@ const itemEvents = Object.freeze({
   ITEM_ORDER_UPDATED: "item:orderUpdated",
 });
 
-module.exports = { roomActions, COLORS, sectionEvents, itemEvents };
+const ITEMS_FIELD = "items";
+
+module.exports = { roomActions, COLORS, sectionEvents, itemEvents, ITEMS_FIELD };

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -2,15 +2,16 @@ const roomActions = Object.freeze({
   LEAVE: "leave-room",
   JOIN: "join-room",
   USERS: "room-users",
+  DISCONNECTING: "disconnecting",
 });
 
-const COLORS = [
+const COLORS = [ // array of colors for users
   "#ff6b6b",
   "#ffd93d",
   "#6bcb77",
   "#4d96ff",
   "#a66cff",
-  "#ff6F91",
+  "#ff6f91",
   "#ff9671",
 ];
 

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -1,7 +1,6 @@
 /*
-* This file handles the MongoDB connection
-*/
-
+ * This file handles the MongoDB connection
+ */
 
 const mongoose = require("mongoose");
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/3c1fd14c-ea42-4e13-b36c-4f9897640a0d

## Description
- When a user edits items (adding, deleting, updating, moving) it is broadcasted and reflected to all other users in the room.

## Milestones
- Completed [this task](https://www.internalfb.com/gsd/1356711632221200/1381714906220093/list?t=228500172) and [this task](https://www.internalfb.com/gsd/1356711632221200/1381714906220093/list?t=228500176)
- Working toward [TC1](https://docs.google.com/document/d/17RSJuYlG4pfWKkTmupSPv2IiZi_5vMlE9Ugr8SYhYK4/edit?tab=t.w6c6clm02r58#heading=h.xxruen6kc9ke)

## Problem-Solving Process:
- While implementing this functionality for the items was very similar to that of the sections, it still came with some challenges. 
- The biggest difference was that sections can only have their order rearranged, while items can have their order rearranged AND be moved between sections. 
- I decided it would be easiest to include this moving between sections functionality within my update item endpoint for sake of maintaining reusable code. 
- Then I could just change it's parent section id & rerender the parent section components. 

## Working on next...
- Multi-user UI updates
- Conflict Resolution

