### PR TITLE
Action logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Logs
-logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/client/src/components/main-content/Add/AddButton.css
+++ b/client/src/components/main-content/Add/AddButton.css
@@ -14,12 +14,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px !important;
-  height: 48px !important;
-  min-width: 48px !important;
-  min-height: 48px !important;
-  max-width: 48px !important;
-  max-height: 48px !important;
+  width: 45px !important;
+  height: 45px !important;
+  min-width: 45px !important;
+  min-height: 45px !important;
+  max-width: 45px !important;
+  max-height: 45px !important;
   box-sizing: border-box;
   flex: 0 0 auto !important;
 }

--- a/client/src/components/main-content/Logs/Logs.css
+++ b/client/src/components/main-content/Logs/Logs.css
@@ -1,0 +1,41 @@
+.logs-bar {
+  width: 100%;
+  position: absolute;
+  bottom: 25px;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  z-index: 100;
+}
+
+.logs-scroll {
+  color: #f5f5eab8;
+  border-radius: 8px;
+  max-width: 60vw;
+  min-width: 300px;
+  max-height: 60px;
+  overflow-y: auto;
+  font-size: 0.75em;
+  box-shadow: 0 2px 8px #000a;
+  text-align: center;
+  position: relative;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  background: transparent;
+  -webkit-mask-image: linear-gradient(to bottom, transparent, black 20%, black 80%, transparent);
+  mask-image: linear-gradient(to bottom, transparent, black 30%, black 80%, transparent);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  padding: 5px;
+}
+.logs-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.log-entry {
+  margin-bottom: 2px;
+  white-space: pre-line;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+

--- a/client/src/components/main-content/Logs/Logs.jsx
+++ b/client/src/components/main-content/Logs/Logs.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+import "./Logs.css";
+
+const Logs = ({ logs }) => {
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [logs]);
+
+  return (
+    <div className="logs-bar">
+      <div className="logs-scroll" ref={scrollRef}>
+        {logs.map((log, i) => (
+          <div key={i} className="log-entry">
+            {log}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Logs;

--- a/client/src/hooks/useDragHandlers.js
+++ b/client/src/hooks/useDragHandlers.js
@@ -1,0 +1,90 @@
+const URL = import.meta.env.VITE_API_URL;
+import { SectionActions } from "../utils/constants";
+
+const useDragHandlers = ({
+  setActiveId,
+  activeId,
+  activeIdRef,
+  setShowModal,
+  setShowItemModal,
+  setTargetSectionId,
+  setSections,
+  setSectionOrder,
+  sections,
+  getAccessTokenSilently,
+  username,
+  currentUser,
+  addLog,
+  userId,
+  color,
+  roomId,
+  handleMouseMoveWhileDragging,
+  setDragPosition,
+  socket,
+  cursorEvents,
+  handleDragEndUtil,
+  setIsDeleteZoneOver,
+}) => {
+  const handleDragStart = (event) => {
+    setActiveId(event.active.id);
+    activeIdRef.current = event.active.id;
+    // initial position
+    setDragPosition({
+      x: event.activatorEvent?.clientX ?? 0,
+      y: event.activatorEvent?.clientY ?? 0,
+    });
+    socket.emit(cursorEvents.COMPONENT_DRAG_START, {
+      roomId,
+      userId,
+      color,
+      id: event.active.id,
+      type: event.active.data.current?.type,
+    });
+    window.addEventListener("mousemove", handleMouseMoveWhileDragging);
+  };
+
+  const handleDragEnd = (event) => {
+    window.removeEventListener("mousemove", handleMouseMoveWhileDragging);
+    socket.emit(cursorEvents.COMPONENT_DRAG_END, {
+      roomId,
+      userId,
+      color,
+      id: event.active.id,
+    });
+    if (event.active && event.over && event.active.id !== event.over.id) {
+      const section = sections[event.active.id];
+      if (section) {
+        addLog(`You moved section "${section.title}"`);
+      }
+    }
+    setActiveId(null);
+    handleDragEndUtil(event, {
+      setActiveId,
+      activeId,
+      setShowModal,
+      setShowItemModal,
+      setTargetSectionId,
+      setSections,
+      setSectionOrder,
+      sections,
+      getAccessTokenSilently,
+      username,
+      currentUser,
+      addLog,
+    });
+  };
+
+  const handleDragOver = (event) => {
+    const { over } = event;
+    setIsDeleteZoneOver(over?.id === SectionActions.DELETE_ZONE);
+  };
+
+
+  return {
+    handleDragStart,
+    handleDragEnd,
+    handleDragOver,
+  };
+};
+
+export default useDragHandlers;

--- a/client/src/hooks/useSaveHandlers.js
+++ b/client/src/hooks/useSaveHandlers.js
@@ -1,0 +1,96 @@
+const URL = import.meta.env.VITE_API_URL;
+
+const useSaveHandlers = ({
+  setShowModal,
+  setShowItemModal,
+  setTargetSectionId,
+  setSections,
+  setSectionOrder,
+  getAccessTokenSilently,
+  username,
+  currentUser,
+  addLog,
+  setPendingSectionTitle,
+  pendingSectionTitle,
+  editingItem,
+  setEditingItem,
+  targetSectionId,
+  apiFetch,
+}) => {
+  const handleSaveSection = async () => {
+    const newSection = await apiFetch({
+      endpoint: `${URL}/api/sections/${username}`,
+      method: "POST",
+      body: { title: pendingSectionTitle, username: currentUser?.nickname },
+      getAccessTokenSilently,
+    });
+
+    const sectionId = newSection.id || newSection._id;
+
+    setSections((prev) => ({
+      ...prev,
+      [sectionId]: { ...newSection, id: sectionId, items: [] },
+    }));
+    setSectionOrder((prev) => [...prev, sectionId]);
+    if (addLog) {
+      addLog(`You created section "${newSection.title}"`);
+    }
+    setShowModal(false);
+    setPendingSectionTitle("");
+  };
+
+  const handleSaveItem = async ({ content, link, notes }) => {
+    if (!content.trim() || !targetSectionId) {
+      if (editingItem) {
+        addLog(`You edited item "${editingItem.content}"`);
+      } else {
+        addLog(`${currentUser?.nickname || "Someone"} added item "${content}"`);
+      }
+      setShowItemModal(false);
+      setEditingItem(null);
+      setTargetSectionId(null);
+      return;
+    }
+
+    if (editingItem) {
+      await apiFetch({
+        endpoint: `${URL}/api/items/${targetSectionId}/items/${editingItem.id}/${username}`,
+        method: "PUT",
+        body: {
+          content,
+          link,
+          notes,
+          sectionId: targetSectionId,
+          username: currentUser?.nickname,
+        },
+        getAccessTokenSilently,
+      });
+      addLog(`You edited item "${editingItem.content}"`);
+    } else {
+      await apiFetch({
+        endpoint: `${URL}/api/items/${targetSectionId}/items/${username}`,
+        method: "POST",
+        body: {
+          content,
+          link,
+          notes,
+          sectionId: targetSectionId,
+          username: currentUser?.nickname,
+        },
+        getAccessTokenSilently,
+      });
+      addLog(`You added item "${content}"`);
+    }
+
+    setShowItemModal(false);
+    setEditingItem(null);
+    setTargetSectionId(null);
+  };
+
+  return {
+    handleSaveSection,
+    handleSaveItem,
+  };
+};
+
+export default useSaveHandlers;

--- a/client/src/hooks/useSectionSocketHandlers.jsx
+++ b/client/src/hooks/useSectionSocketHandlers.jsx
@@ -39,7 +39,7 @@ const useSectionSocketHandlers = ({
       }
     };
 
-    const handleSectionDeleted = ({ sectionId, username: eventUsername }) => {
+    const handleSectionDeleted = ({ sectionId, username: eventUsername, title }) => {
       setSections((prev) => {
         const copy = { ...prev };
         delete copy[sectionId];
@@ -47,14 +47,14 @@ const useSectionSocketHandlers = ({
       });
       setSectionOrder((prev) => prev.filter((id) => id !== sectionId));
       if (addLog && eventUsername && eventUsername !== username) {
-        addLog(`${eventUsername || "Someone"} deleted a section`);
+        addLog(`${eventUsername || "Someone"} deleted section "${title}"`);
       }
     };
 
-    const handleSectionOrderUpdated = ({ order, username: eventUsername }) => {
+    const handleSectionOrderUpdated = ({ order, username: eventUsername, title }) => {
       setSectionOrder(order);
       if (addLog && eventUsername && eventUsername !== username) {
-        addLog(`${eventUsername || "Someone"} reordered sections`);
+        addLog(`${eventUsername || "Someone"} reordered section ${title}`);
       }
     };
 

--- a/client/src/utils/sectionListUtils.js
+++ b/client/src/utils/sectionListUtils.js
@@ -1,4 +1,3 @@
-// todo: consolodate function parameters into 1 object
 import {
   SectionActions,
   DragEndActions,
@@ -147,9 +146,6 @@ const handleDragEndItem = (
 const handleDragEndAdd = (active, over, { setShowModal, setActiveId, currentUser, addLog }) => {
   setShowModal(true);
   setActiveId(null);
-  if (addLog) {
-    addLog(`You created section "${active.id}"`);
-  }
 };
 
 const handleDragEndDelete = (

--- a/client/src/utils/sectionListUtils.js
+++ b/client/src/utils/sectionListUtils.js
@@ -32,7 +32,7 @@ const handleDragEndSection = (
         await apiFetch({
           endpoint: `${URL}/api/sections/user/${username}/order`,
           method: "PUT",
-          body: { order: newOrder, username: currentUser?.nickname },
+          body: { order: newOrder, username: currentUser?.nickname, movedId: active.id },
           getAccessTokenSilently,
         });
       })();

--- a/server/controllers/itemController.js
+++ b/server/controllers/itemController.js
@@ -90,7 +90,7 @@ exports.updateItemOrder = async (req, res) => {
     if (!section) return res.status(404).json({ error: "Section not found" });
     let content = '';
     if (section.items.length > 0) {
-      const firstItem = section.items.find(i => i._id.toString() === order[0]); // Find the first item in the new order and get its content
+      const firstItem = section.items.find(i => i._id.toString() === order[0]);
       content = firstItem?.content || '';
     }
     itemEvents.emitItemOrderUpdated(

--- a/server/controllers/itemController.js
+++ b/server/controllers/itemController.js
@@ -30,7 +30,10 @@ exports.createItem = async (req, res) => {
     section.items.push(newItem._id);
     await section.save();
 
-    itemEvents.emitItemCreated(req.params.username, newItem);
+    itemEvents.emitItemCreated(req.params.username, {
+      ...newItem.toObject(),
+      username: req.body.username,
+    });
 
     res.status(201).json(newItem);
   } catch (err) {
@@ -55,13 +58,20 @@ exports.updateItem = async (req, res) => {
     await item.save();
 
     if (oldSectionId !== newSectionId) {
-      await Section.findByIdAndUpdate(oldSectionId, { $pull: { items: item._id } });
-      await Section.findByIdAndUpdate(newSectionId, { $addToSet: { items: item._id } });
+      await Section.findByIdAndUpdate(oldSectionId, {
+        $pull: { items: item._id },
+      });
+      await Section.findByIdAndUpdate(newSectionId, {
+        $addToSet: { items: item._id },
+      });
     }
 
     const updatedItem = await Item.findById(item._id);
 
-    itemEvents.emitItemUpdated(req.params.username, updatedItem);
+    itemEvents.emitItemUpdated(req.params.username, {
+      ...item.toObject(),
+      username: req.body.username,
+    });
 
     res.json(updatedItem);
   } catch (err) {
@@ -76,9 +86,20 @@ exports.updateItemOrder = async (req, res) => {
       req.params.sectionId,
       { items: order },
       { new: true }
-    );
+    ).populate('items');
     if (!section) return res.status(404).json({ error: "Section not found" });
-    itemEvents.emitItemOrderUpdated(req.params.username, section._id.toString(), order);
+    let content = '';
+    if (section.items.length > 0) {
+      const firstItem = section.items.find(i => i._id.toString() === order[0]); // Find the first item in the new order and get its content
+      content = firstItem?.content || '';
+    }
+    itemEvents.emitItemOrderUpdated(
+      req.params.username,
+      section._id.toString(),
+      order,
+      req.body.username,
+      content
+    );
     res.json({ success: true });
   } catch (err) {
     console.error("updateItemOrder error:", err);
@@ -99,14 +120,20 @@ exports.moveItem = async (req, res) => {
     if (!item) return res.status(404).json({ error: "Item not found" });
 
     const fromSection = await Section.findById(sectionId);
-    if (!fromSection) return res.status(404).json({ error: "Source section not found" });
+    if (!fromSection)
+      return res.status(404).json({ error: "Source section not found" });
     fromSection.items.pull(item._id);
     await fromSection.save();
 
     const toSection = await Section.findById(toSectionId);
-    if (!toSection) return res.status(404).json({ error: "Destination section not found" });
+    if (!toSection)
+      return res.status(404).json({ error: "Destination section not found" });
 
-    if (typeof toIndex === "number" && toIndex >= 0 && toIndex <= toSection.items.length) {
+    if (
+      typeof toIndex === "number" &&
+      toIndex >= 0 &&
+      toIndex <= toSection.items.length
+    ) {
       toSection.items.splice(toIndex, 0, item._id);
     } else {
       toSection.items.push(item._id);
@@ -116,7 +143,10 @@ exports.moveItem = async (req, res) => {
     item.sectionId = toSectionId;
     await item.save();
 
-    itemEvents.emitItemUpdated(req.params.username, item);
+    itemEvents.emitItemUpdated(req.params.username, {
+      ...item.toObject(),
+      username: req.body.username,
+    });
 
     res.json({ success: true, item });
   } catch (err) {
@@ -124,18 +154,25 @@ exports.moveItem = async (req, res) => {
     res.status(500).json({ error: "Server error" });
   }
 };
-    
 
 exports.deleteItem = async (req, res) => {
   try {
     const section = await Section.findById(req.params.sectionId);
     if (!section) return res.status(404).json({ error: "Section not found" });
 
+    const item = await Item.findById(req.params.itemId);
+    if (!item) return res.status(404).json({ error: "Item not found" });
+
     await Item.findByIdAndDelete(req.params.itemId);
     section.items.pull(req.params.itemId);
     await section.save();
 
-    itemEvents.emitItemDeleted(req.params.username, req.params.itemId);
+    itemEvents.emitItemDeleted(
+      req.params.username,
+      req.params.itemId,
+      req.body.username,
+      item.content
+    );
 
     res.status(204).send();
   } catch (err) {

--- a/server/controllers/sectionController.js
+++ b/server/controllers/sectionController.js
@@ -50,7 +50,7 @@ exports.updateSectionOrder = async (req, res) => {
       { new: true }
     );
     if (!user) return res.status(404).json({ error: "User not found" });
-    sectionEvents.emitSectionOrderUpdated(req.params.username, order);
+    sectionEvents.emitSectionOrderUpdated(req.params.username, order, req.body.username);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: "Server error" });
@@ -72,7 +72,7 @@ exports.createSection = async (req, res) => {
     );
 
     // push to other users
-    sectionEvents.emitSectionCreated(req.params.username, newSection);
+    sectionEvents.emitSectionCreated(req.params.username, { ...newSection.toObject(), username: req.body.username });
 
     res.status(201).json(newSection);
   } catch (err) {
@@ -87,7 +87,7 @@ exports.updateSection = async (req, res) => {
     });
     if (!section) return res.status(404).json({ error: "Section not found" });
 
-    sectionEvents.emitSectionUpdated(req.params.username, section);
+    sectionEvents.emitSectionUpdated(req.params.username, { ...section.toObject(), username: req.body.username });
 
     res.json(section);
   } catch (err) {
@@ -100,7 +100,7 @@ exports.deleteSection = async (req, res) => {
     const section = await Section.findByIdAndDelete(req.params.id);
     if (!section) return res.status(404).json({ error: "Section not found" });
 
-    sectionEvents.emitSectionDeleted(req.params.username, section._id);
+    sectionEvents.emitSectionDeleted(req.params.username, req.params.id, req.body.username);
 
     res.status(204).send();
   } catch (err) {

--- a/server/events/itemEvents.js
+++ b/server/events/itemEvents.js
@@ -6,21 +6,29 @@ let io = null;
 const { itemEvents } = require("../utils/constants");
 
 module.exports = {
-  init: (_io) => { io = _io; },
+  init: (_io) => {
+    io = _io;
+  },
 
   emitItemCreated: (roomId, item) => {
     if (io) io.to(roomId).emit(itemEvents.ITEM_CREATED, item);
   },
 
   emitItemUpdated: (roomId, item) => {
-   if (io) io.to(roomId).emit(itemEvents.ITEM_UPDATED, item);
+    if (io) io.to(roomId).emit(itemEvents.ITEM_UPDATED, item);
   },
 
-  emitItemDeleted: (roomId, itemId) => {
-    if (io) io.to(roomId).emit(itemEvents.ITEM_DELETED, { itemId });
+  emitItemDeleted: (roomId, itemId, username, content) => {
+    if (io) io.to(roomId).emit(itemEvents.ITEM_DELETED, { itemId, username, content });
   },
 
-  emitItemOrderUpdated: (roomId, sectionId, order) => {
-    if (io) io.to(roomId).emit(itemEvents.ITEM_ORDER_UPDATED, { sectionId, order });
-  }
+  emitItemOrderUpdated: (roomId, sectionId, order, username, content) => {
+    if (io)
+      io.to(roomId).emit(itemEvents.ITEM_ORDER_UPDATED, {
+        sectionId,
+        order,
+        username,
+        content
+      });
+  },
 };

--- a/server/events/sectionEvents.js
+++ b/server/events/sectionEvents.js
@@ -16,11 +16,11 @@ module.exports = {
     if (io) io.to(roomId).emit(sectionEvents.SECTION_UPDATED, section);
   },
 
-  emitSectionDeleted: (roomId, sectionId, username) => {
-    if (io) io.to(roomId).emit(sectionEvents.SECTION_DELETED, { sectionId, username });
+  emitSectionDeleted: (roomId, sectionId, username, title) => {
+    if (io) io.to(roomId).emit(sectionEvents.SECTION_DELETED, { sectionId, username, title });
   },
 
-  emitSectionOrderUpdated: (roomId, order, username) => {
-    if (io) io.to(roomId).emit(sectionEvents.SECTION_ORDER_UPDATED, { order, username });
+  emitSectionOrderUpdated: (roomId, order, username, title) => {
+    if (io) io.to(roomId).emit(sectionEvents.SECTION_ORDER_UPDATED, { order, username, title });
   }
 };

--- a/server/events/sectionEvents.js
+++ b/server/events/sectionEvents.js
@@ -16,11 +16,11 @@ module.exports = {
     if (io) io.to(roomId).emit(sectionEvents.SECTION_UPDATED, section);
   },
 
-  emitSectionDeleted: (roomId, sectionId) => {
-    if (io) io.to(roomId).emit(sectionEvents.SECTION_DELETED, { sectionId });
+  emitSectionDeleted: (roomId, sectionId, username) => {
+    if (io) io.to(roomId).emit(sectionEvents.SECTION_DELETED, { sectionId, username });
   },
 
-  emitSectionOrderUpdated: (roomId, order) => {
-    if (io) io.to(roomId).emit(sectionEvents.SECTION_ORDER_UPDATED, order);
+  emitSectionOrderUpdated: (roomId, order, username) => {
+    if (io) io.to(roomId).emit(sectionEvents.SECTION_ORDER_UPDATED, { order, username });
   }
 };


### PR DESCRIPTION
https://github.com/user-attachments/assets/b64d7e9b-c1fe-428d-8010-6ac120a2d71e
## Description
- Added a log system that displays user actions
- It's only on the client side, so it doesn't persist after refresh
- The purpose of it is to let users know the actions of other users, so if 2 users move things around simultaneously, it's easy to keep track of. 

## Milestones
- Completed [this task](https://www.internalfb.com/gsd/1356711632221200/1381714906220093/list?t=228500181)

## Challenges Faced/Problem Solving Process
- This feature ended up being more worked than I initially thought
- This is because throughout my code I mainly only used users nicknames for the room ID.  
- However, for these events I wanted to display the users nicknames instead of their 'arbitrary' ID.
- So, in my api calls, I now pass the nickname in from the frontend, and attach it on to the item being moved.
- This is then emitted to the frontend, so the frontend can access the nickname of the user that moved the item. 

## Working on next...
- Throttling


(FYI: this pr is pretty large. A lot of it comes from refactoring and moving some of the code into new files)